### PR TITLE
Update Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: '/'
     open-pull-requests-limit: 10
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
# Description of Changes
Change Dependabot to be a weekly package bump instead of daily